### PR TITLE
need to fix a typo in "intro/prerequisites.md" file

### DIFF
--- a/intro/prerequisites.md
+++ b/intro/prerequisites.md
@@ -15,6 +15,6 @@ We expect Software Developers and Systems Administrators using Firehose to have 
 
 ## Requirements
 
-Full Firehose spins up a full node blockchain node (an [Ethereum full node](https://ethereum.org/en/run-a-node/) on Ethereum, a [NEAR full node](https://near-nodes.io/rpc) on NEAR, etc.)
+Full Firehose spins up a full blockchain node (an [Ethereum full node](https://ethereum.org/en/run-a-node/) on Ethereum, a [NEAR full node](https://near-nodes.io/rpc) on NEAR, etc.)
 
 Each blockchain has specific hardware and internet connection requirements. Refer to the specific vendor's documentation for the target blockchain.


### PR DESCRIPTION
The "intro/prerequisites.md" have a typo error in line 18, instead of "a full node blockchain node" it should be "a full blockchain node"