### PR TITLE
Unnecessarily presence of 4 asterick signs

### DIFF
--- a/firehose-setup/ethereum/local-deployment.md
+++ b/firehose-setup/ethereum/local-deployment.md
@@ -173,7 +173,7 @@ After issuing the start command to the terminal it can take up to thirty seconds
 
 Logging will be rapidly printed to the terminal window. See the log below for example logging.
 
-Press _****_ and hold the Control key and then press the C key three times to terminate Firehose and end all processes.
+Press and hold the Control key and then press the C key three times to terminate Firehose and end all processes.
 
 ```bash
 2022-09-05T12:25:01.208-0700 INFO (<n/a>) registering development exporters from environment variables


### PR DESCRIPTION
The instruction regarding the termination of Firehose and all processes related to it contain "****"  signs which is unnecessarily present there, to more clear instruction it needs to be removed from there.